### PR TITLE
Support different game modes

### DIFF
--- a/src/apps/tengen/BoardPresenter.cpp
+++ b/src/apps/tengen/BoardPresenter.cpp
@@ -1,4 +1,5 @@
 #include "BoardPresenter.hpp"
+#include "tengen/IGameSession.hpp"
 
 #include <QMetaObject>
 #include <QObject>
@@ -7,7 +8,7 @@
 
 namespace tengen {
 
-BoardPresenter::BoardPresenter(app::SessionManager& game, gui::BoardWidget& boardWidget) : m_game(game), m_boardWidget(boardWidget) {
+BoardPresenter::BoardPresenter(app::IGameSession& game, gui::BoardWidget& boardWidget) : m_game(game), m_boardWidget(boardWidget) {
 	QObject::connect(&m_boardWidget, &gui::BoardWidget::boardEvent, &m_boardWidget, [this](const gui::BoardWidgetEvent& event) { this->onBoardEvent(event); });
 	m_boardWidget.setBoard(m_game.board());
 	m_game.subscribe(this, app::AS_BoardChange);

--- a/src/apps/tengen/BoardPresenter.cpp
+++ b/src/apps/tengen/BoardPresenter.cpp
@@ -9,7 +9,7 @@
 namespace tengen {
 
 BoardPresenter::BoardPresenter(app::IGameSession& game, gui::BoardWidget& boardWidget) : m_game(game), m_boardWidget(boardWidget) {
-	QObject::connect(&m_boardWidget, &gui::BoardWidget::boardEvent, &m_boardWidget, [this](const gui::BoardWidgetEvent& event) { this->onBoardEvent(event); });
+	QObject::connect(&m_boardWidget, &gui::BoardWidget::boardEvent, this, &BoardPresenter::onBoardEvent);
 	m_boardWidget.setBoard(m_game.board());
 	m_game.subscribe(this, app::AS_BoardChange);
 }

--- a/src/apps/tengen/BoardPresenter.hpp
+++ b/src/apps/tengen/BoardPresenter.hpp
@@ -3,18 +3,23 @@
 #include "gui/boardWidget.hpp"
 #include "tengen/IGameSession.hpp"
 
+#include <QObject>
+
 namespace tengen {
 
-class BoardPresenter : public app::IAppSignalListener {
+class BoardPresenter : public QObject, public app::IAppSignalListener {
+	Q_OBJECT
+
 public:
 	BoardPresenter(app::IGameSession& game, gui::BoardWidget& boardWidget);
 	~BoardPresenter() override;
 
 	void onAppEvent(app::AppSignal signal) override; //!< Called by the game thread. Ensure not blocking.
 
-private:
+private slots:
 	void onBoardEvent(const gui::BoardWidgetEvent& event);
 
+private:
 	app::IGameSession& m_game;
 	gui::BoardWidget& m_boardWidget;
 };

--- a/src/apps/tengen/BoardPresenter.hpp
+++ b/src/apps/tengen/BoardPresenter.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "gui/boardWidget.hpp"
-#include "tengen/sessionManager.hpp"
+#include "tengen/IGameSession.hpp"
 
 namespace tengen {
 
 class BoardPresenter : public app::IAppSignalListener {
 public:
-	BoardPresenter(app::SessionManager& game, gui::BoardWidget& boardWidget);
+	BoardPresenter(app::IGameSession& game, gui::BoardWidget& boardWidget);
 	~BoardPresenter() override;
 
 	void onAppEvent(app::AppSignal signal) override; //!< Called by the game thread. Ensure not blocking.
@@ -15,7 +15,7 @@ public:
 private:
 	void onBoardEvent(const gui::BoardWidgetEvent& event);
 
-	app::SessionManager& m_game;
+	app::IGameSession& m_game;
 	gui::BoardWidget& m_boardWidget;
 };
 

--- a/src/apps/tengen/CMakeLists.txt
+++ b/src/apps/tengen/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(${targetName}
     "${CMAKE_CURRENT_LIST_DIR}/Logging.cpp"
 )
 
-target_link_libraries(${targetName} 
+target_link_libraries(${targetName}
     PRIVATE
         Logger::Logger
         tengen::game::runtime
@@ -24,9 +24,10 @@ target_link_libraries(${targetName}
         Qt6::Widgets
 )
 
-set_target_properties(${targetName} PROPERTIES AUTOMOC ON) # Auto handling of QT Meta-Object Compiler
-target_compile_definitions(${targetName} PRIVATE TEXTURE_BLACK="${CMAKE_SOURCE_DIR}/assets/anime_black.png")
-target_compile_definitions(${targetName} PRIVATE TEXTURE_WHITE="${CMAKE_SOURCE_DIR}/assets/anime_white.png")
+set_target_properties(${targetName}
+    PROPERTIES
+        AUTOMOC ON # Auto handling of QT Meta-Object Compiler
+)
 
 # Setup project settings
 set_target_configuration(${targetName} Config::Default)

--- a/src/apps/tengen/ChatPresenter.cpp
+++ b/src/apps/tengen/ChatPresenter.cpp
@@ -6,6 +6,7 @@
 #include <QObject>
 
 #include <vector>
+#include <format>
 
 namespace tengen {
 

--- a/src/apps/tengen/ChatPresenter.cpp
+++ b/src/apps/tengen/ChatPresenter.cpp
@@ -5,8 +5,8 @@
 #include <QMetaObject>
 #include <QObject>
 
-#include <vector>
 #include <format>
+#include <vector>
 
 namespace tengen {
 

--- a/src/apps/tengen/ChatPresenter.cpp
+++ b/src/apps/tengen/ChatPresenter.cpp
@@ -10,14 +10,15 @@
 
 namespace tengen {
 
-ChatPresenter::ChatPresenter(app::IChatSession& game, gui::ChatWidget& chatWidget) : m_game(game), m_chatWidget(chatWidget) {
-	QObject::connect(&m_chatWidget, &gui::ChatWidget::chatEvent, &m_chatWidget, [this](const std::string& message) { this->m_game.chat(message); });
+ChatPresenter::ChatPresenter(app::IChatSession& chat, gui::ChatWidget& chatWidget) : m_chat(chat), m_chatWidget(chatWidget) {
+	QObject::connect(&m_chatWidget, &gui::ChatWidget::chatEvent, &m_chatWidget, [this](const std::string& message) { m_chat.chat(message); });
 
-	m_game.subscribe(this, app::AS_NewChat);
+	m_chat.subscribe(this, app::AS_NewChat);
+	onAppEvent(app::AS_NewChat);
 }
 
 ChatPresenter::~ChatPresenter() {
-	m_game.unsubscribe(this);
+	m_chat.unsubscribe(this);
 }
 
 void ChatPresenter::onAppEvent(const app::AppSignal signal) {
@@ -25,7 +26,7 @@ void ChatPresenter::onAppEvent(const app::AppSignal signal) {
 		return;
 	}
 
-	const auto messageEntries = m_game.getChatSince(m_lastChatMessageId);
+	const auto messageEntries = m_chat.getChatSince(m_lastChatMessageId);
 	if (messageEntries.empty()) {
 		return;
 	}

--- a/src/apps/tengen/ChatPresenter.cpp
+++ b/src/apps/tengen/ChatPresenter.cpp
@@ -1,7 +1,6 @@
 #include "ChatPresenter.hpp"
 
 #include "gui/chatWidget.hpp"
-#include "tengen/IGameSession.hpp"
 
 #include <QMetaObject>
 #include <QObject>
@@ -10,7 +9,7 @@
 
 namespace tengen {
 
-ChatPresenter::ChatPresenter(app::IGameSession& game, gui::ChatWidget& chatWidget) : m_game(game), m_chatWidget(chatWidget) {
+ChatPresenter::ChatPresenter(app::IChatSession& game, gui::ChatWidget& chatWidget) : m_game(game), m_chatWidget(chatWidget) {
 	QObject::connect(&m_chatWidget, &gui::ChatWidget::chatEvent, &m_chatWidget, [this](const std::string& message) { this->m_game.chat(message); });
 
 	m_game.subscribe(this, app::AS_NewChat);

--- a/src/apps/tengen/ChatPresenter.cpp
+++ b/src/apps/tengen/ChatPresenter.cpp
@@ -1,16 +1,16 @@
 #include "ChatPresenter.hpp"
 
 #include "gui/chatWidget.hpp"
+#include "tengen/IGameSession.hpp"
 
 #include <QMetaObject>
 #include <QObject>
 
-#include <format>
 #include <vector>
 
 namespace tengen {
 
-ChatPresenter::ChatPresenter(app::SessionManager& game, gui::ChatWidget& chatWidget) : m_game(game), m_chatWidget(chatWidget) {
+ChatPresenter::ChatPresenter(app::IGameSession& game, gui::ChatWidget& chatWidget) : m_game(game), m_chatWidget(chatWidget) {
 	QObject::connect(&m_chatWidget, &gui::ChatWidget::chatEvent, &m_chatWidget, [this](const std::string& message) { this->m_game.chat(message); });
 
 	m_game.subscribe(this, app::AS_NewChat);

--- a/src/apps/tengen/ChatPresenter.cpp
+++ b/src/apps/tengen/ChatPresenter.cpp
@@ -11,7 +11,7 @@
 namespace tengen {
 
 ChatPresenter::ChatPresenter(app::IChatSession& chat, gui::ChatWidget& chatWidget) : m_chat(chat), m_chatWidget(chatWidget) {
-	QObject::connect(&m_chatWidget, &gui::ChatWidget::chatEvent, &m_chatWidget, [this](const std::string& message) { m_chat.chat(message); });
+	QObject::connect(&m_chatWidget, &gui::ChatWidget::chatEvent, this, &ChatPresenter::onChatRequested);
 
 	m_chat.subscribe(this, app::AS_NewChat);
 	onAppEvent(app::AS_NewChat);
@@ -19,6 +19,10 @@ ChatPresenter::ChatPresenter(app::IChatSession& chat, gui::ChatWidget& chatWidge
 
 ChatPresenter::~ChatPresenter() {
 	m_chat.unsubscribe(this);
+}
+
+void ChatPresenter::onChatRequested(const std::string& message) {
+	m_chat.chat(message);
 }
 
 void ChatPresenter::onAppEvent(const app::AppSignal signal) {

--- a/src/apps/tengen/ChatPresenter.hpp
+++ b/src/apps/tengen/ChatPresenter.hpp
@@ -16,7 +16,7 @@ public:
 	void onAppEvent(app::AppSignal signal) override; //!< Called by the game thread. Ensure not blocking.
 
 private:
-	app::IChatSession& m_game;
+	app::IChatSession& m_chat;
 	gui::ChatWidget& m_chatWidget;
 
 	unsigned m_lastChatMessageId = 0u;

--- a/src/apps/tengen/ChatPresenter.hpp
+++ b/src/apps/tengen/ChatPresenter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "tengen/sessionManager.hpp"
+#include "tengen/IGameSession.hpp"
 
 namespace tengen {
 
@@ -10,13 +10,13 @@ class ChatWidget;
 
 class ChatPresenter : public app::IAppSignalListener {
 public:
-	ChatPresenter(app::SessionManager& game, gui::ChatWidget& chatWidget);
+	ChatPresenter(app::IGameSession& game, gui::ChatWidget& chatWidget);
 	~ChatPresenter() override;
 
 	void onAppEvent(app::AppSignal signal) override; //!< Called by the game thread. Ensure not blocking.
 
 private:
-	app::SessionManager& m_game;
+	app::IGameSession& m_game;
 	gui::ChatWidget& m_chatWidget;
 
 	unsigned m_lastChatMessageId = 0u;

--- a/src/apps/tengen/ChatPresenter.hpp
+++ b/src/apps/tengen/ChatPresenter.hpp
@@ -2,18 +2,25 @@
 
 #include "tengen/IChatSession.hpp"
 
+#include <QObject>
+
 namespace tengen {
 
 namespace gui {
 class ChatWidget;
 }
 
-class ChatPresenter : public app::IAppSignalListener {
+class ChatPresenter : public QObject, public app::IAppSignalListener {
+	Q_OBJECT
+
 public:
 	ChatPresenter(app::IChatSession& chat, gui::ChatWidget& chatWidget);
 	~ChatPresenter() override;
 
 	void onAppEvent(app::AppSignal signal) override; //!< Called by the game thread. Ensure not blocking.
+
+private slots:
+	void onChatRequested(const std::string& message);
 
 private:
 	app::IChatSession& m_chat;

--- a/src/apps/tengen/ChatPresenter.hpp
+++ b/src/apps/tengen/ChatPresenter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "tengen/IGameSession.hpp"
+#include "tengen/IChatSession.hpp"
 
 namespace tengen {
 
@@ -10,13 +10,13 @@ class ChatWidget;
 
 class ChatPresenter : public app::IAppSignalListener {
 public:
-	ChatPresenter(app::IGameSession& game, gui::ChatWidget& chatWidget);
+	ChatPresenter(app::IChatSession& chat, gui::ChatWidget& chatWidget);
 	~ChatPresenter() override;
 
 	void onAppEvent(app::AppSignal signal) override; //!< Called by the game thread. Ensure not blocking.
 
 private:
-	app::IGameSession& m_game;
+	app::IChatSession& m_game;
 	gui::ChatWidget& m_chatWidget;
 
 	unsigned m_lastChatMessageId = 0u;

--- a/src/apps/tengen/GamePresenter.cpp
+++ b/src/apps/tengen/GamePresenter.cpp
@@ -42,6 +42,7 @@ GamePresenter::GamePresenter(app::IGameSession& game, gui::GameWidget& gameWidge
 	QObject::connect(&m_gameWidget, &gui::GameWidget::resignEvent, &m_gameWidget, [this]() { this->onResignRequested(); });
 
 	m_boardPresenter = std::make_unique<BoardPresenter>(m_game, m_gameWidget.boardWidget());
+	m_gameWidget.setChatEnabled(false);
 
 	m_gameWidget.setCurrentPlayerText(currentPlayerText(m_game.currentPlayer()));
 	m_gameWidget.setGameStateText(gameStateText(m_game.status()));
@@ -55,6 +56,7 @@ GamePresenter::~GamePresenter() {
 
 void GamePresenter::addChatWindow(app::IChatSession& chat) {
 	m_chatPresenter = std::make_unique<ChatPresenter>(chat, m_gameWidget.chatWidget());
+	m_gameWidget.setChatEnabled(true);
 }
 
 void GamePresenter::onAppEvent(const app::AppSignal signal) {

--- a/src/apps/tengen/GamePresenter.cpp
+++ b/src/apps/tengen/GamePresenter.cpp
@@ -37,14 +37,11 @@ static QString gameStateText(const tengen::GameStatus status) {
 	}
 }
 
-GamePresenter::GamePresenter(app::IGameSession& game, app::IChatSession* chat, gui::GameWidget& gameWidget) : m_game(game), m_gameWidget(gameWidget) {
+GamePresenter::GamePresenter(app::IGameSession& game, gui::GameWidget& gameWidget) : m_game(game), m_gameWidget(gameWidget) {
 	QObject::connect(&m_gameWidget, &gui::GameWidget::passEvent, &m_gameWidget, [this]() { this->onPassRequested(); });
 	QObject::connect(&m_gameWidget, &gui::GameWidget::resignEvent, &m_gameWidget, [this]() { this->onResignRequested(); });
 
 	m_boardPresenter = std::make_unique<BoardPresenter>(m_game, m_gameWidget.boardWidget());
-	if(chat) {
-	    m_chatPresenter  = std::make_unique<ChatPresenter>(chat, m_gameWidget.chatWidget());
-	}
 
 	m_gameWidget.setCurrentPlayerText(currentPlayerText(m_game.currentPlayer()));
 	m_gameWidget.setGameStateText(gameStateText(m_game.status()));
@@ -54,6 +51,10 @@ GamePresenter::GamePresenter(app::IGameSession& game, app::IChatSession* chat, g
 
 GamePresenter::~GamePresenter() {
 	m_game.unsubscribe(this);
+}
+
+void GamePresenter::addChatWindow(app::IChatSession& chat) {
+    m_chatPresenter  = std::make_unique<ChatPresenter>(chat, m_gameWidget.chatWidget());
 }
 
 void GamePresenter::onAppEvent(const app::AppSignal signal) {

--- a/src/apps/tengen/GamePresenter.cpp
+++ b/src/apps/tengen/GamePresenter.cpp
@@ -1,4 +1,5 @@
 #include "GamePresenter.hpp"
+#include "tengen/IGameSession.hpp"
 
 #include <QMetaObject>
 #include <QObject>
@@ -36,7 +37,7 @@ static QString gameStateText(const tengen::GameStatus status) {
 	}
 }
 
-GamePresenter::GamePresenter(app::SessionManager& game, gui::GameWidget& gameWidget) : m_game(game), m_gameWidget(gameWidget) {
+GamePresenter::GamePresenter(app::IGameSession& game, gui::GameWidget& gameWidget) : m_game(game), m_gameWidget(gameWidget) {
 	QObject::connect(&m_gameWidget, &gui::GameWidget::passEvent, &m_gameWidget, [this]() { this->onPassRequested(); });
 	QObject::connect(&m_gameWidget, &gui::GameWidget::resignEvent, &m_gameWidget, [this]() { this->onResignRequested(); });
 

--- a/src/apps/tengen/GamePresenter.cpp
+++ b/src/apps/tengen/GamePresenter.cpp
@@ -38,8 +38,8 @@ static QString gameStateText(const tengen::GameStatus status) {
 }
 
 GamePresenter::GamePresenter(app::IGameSession& game, gui::GameWidget& gameWidget) : m_game(game), m_gameWidget(gameWidget) {
-	QObject::connect(&m_gameWidget, &gui::GameWidget::passEvent, &m_gameWidget, [this]() { this->onPassRequested(); });
-	QObject::connect(&m_gameWidget, &gui::GameWidget::resignEvent, &m_gameWidget, [this]() { this->onResignRequested(); });
+	QObject::connect(&m_gameWidget, &gui::GameWidget::passEvent, this, &GamePresenter::onPassRequested);
+	QObject::connect(&m_gameWidget, &gui::GameWidget::resignEvent, this, &GamePresenter::onResignRequested);
 
 	m_boardPresenter = std::make_unique<BoardPresenter>(m_game, m_gameWidget.boardWidget());
 	m_gameWidget.setChatEnabled(false);
@@ -51,6 +51,8 @@ GamePresenter::GamePresenter(app::IGameSession& game, gui::GameWidget& gameWidge
 }
 
 GamePresenter::~GamePresenter() {
+	m_chatPresenter.reset();
+	m_boardPresenter.reset();
 	m_game.unsubscribe(this);
 }
 

--- a/src/apps/tengen/GamePresenter.cpp
+++ b/src/apps/tengen/GamePresenter.cpp
@@ -37,12 +37,14 @@ static QString gameStateText(const tengen::GameStatus status) {
 	}
 }
 
-GamePresenter::GamePresenter(app::IGameSession& game, gui::GameWidget& gameWidget) : m_game(game), m_gameWidget(gameWidget) {
+GamePresenter::GamePresenter(app::IGameSession& game, app::IChatSession* chat, gui::GameWidget& gameWidget) : m_game(game), m_gameWidget(gameWidget) {
 	QObject::connect(&m_gameWidget, &gui::GameWidget::passEvent, &m_gameWidget, [this]() { this->onPassRequested(); });
 	QObject::connect(&m_gameWidget, &gui::GameWidget::resignEvent, &m_gameWidget, [this]() { this->onResignRequested(); });
 
 	m_boardPresenter = std::make_unique<BoardPresenter>(m_game, m_gameWidget.boardWidget());
-	m_chatPresenter  = std::make_unique<ChatPresenter>(m_game, m_gameWidget.chatWidget());
+	if(chat) {
+	    m_chatPresenter  = std::make_unique<ChatPresenter>(chat, m_gameWidget.chatWidget());
+	}
 
 	m_gameWidget.setCurrentPlayerText(currentPlayerText(m_game.currentPlayer()));
 	m_gameWidget.setGameStateText(gameStateText(m_game.status()));

--- a/src/apps/tengen/GamePresenter.cpp
+++ b/src/apps/tengen/GamePresenter.cpp
@@ -54,7 +54,7 @@ GamePresenter::~GamePresenter() {
 }
 
 void GamePresenter::addChatWindow(app::IChatSession& chat) {
-    m_chatPresenter  = std::make_unique<ChatPresenter>(chat, m_gameWidget.chatWidget());
+	m_chatPresenter = std::make_unique<ChatPresenter>(chat, m_gameWidget.chatWidget());
 }
 
 void GamePresenter::onAppEvent(const app::AppSignal signal) {

--- a/src/apps/tengen/GamePresenter.hpp
+++ b/src/apps/tengen/GamePresenter.hpp
@@ -12,8 +12,10 @@ namespace tengen {
 
 class GamePresenter : public app::IAppSignalListener {
 public:
-	GamePresenter(app::IGameSession& game, app::IChatSession* chat, gui::GameWidget& gameWidget);
+	GamePresenter(app::IGameSession& game, gui::GameWidget& gameWidget);
 	~GamePresenter() override;
+
+	void addChatWindow(app::IChatSession& chat);
 
 	void onAppEvent(app::AppSignal signal) override; //!< Called by the game thread. Ensure not blocking.
 	void onPassRequested();                          //!< Handle pass event from Board Widget.

--- a/src/apps/tengen/GamePresenter.hpp
+++ b/src/apps/tengen/GamePresenter.hpp
@@ -3,7 +3,7 @@
 #include "BoardPresenter.hpp"
 #include "ChatPresenter.hpp"
 #include "gui/gameWidget.hpp"
-#include "tengen/sessionManager.hpp"
+#include "tengen/IGameSession.hpp"
 
 #include <memory>
 
@@ -11,7 +11,7 @@ namespace tengen {
 
 class GamePresenter : public app::IAppSignalListener {
 public:
-	GamePresenter(app::SessionManager& game, gui::GameWidget& gameWidget);
+	GamePresenter(app::IGameSession& game, gui::GameWidget& gameWidget);
 	~GamePresenter() override;
 
 	void onAppEvent(app::AppSignal signal) override; //!< Called by the game thread. Ensure not blocking.
@@ -19,7 +19,7 @@ public:
 	void onResignRequested();                        //!< Handle resign event from Board Widget.
 
 private:
-	app::SessionManager& m_game;
+	app::IGameSession& m_game;
 	gui::GameWidget& m_gameWidget;
 	std::unique_ptr<BoardPresenter> m_boardPresenter = nullptr;
 	std::unique_ptr<ChatPresenter> m_chatPresenter   = nullptr;

--- a/src/apps/tengen/GamePresenter.hpp
+++ b/src/apps/tengen/GamePresenter.hpp
@@ -23,8 +23,6 @@ public:
 
 private:
 	app::IGameSession& m_game;
-	app::IChatSession* m_chat{nullptr};
-
 	gui::GameWidget& m_gameWidget;
 	std::unique_ptr<BoardPresenter> m_boardPresenter = nullptr;
 	std::unique_ptr<ChatPresenter> m_chatPresenter   = nullptr;

--- a/src/apps/tengen/GamePresenter.hpp
+++ b/src/apps/tengen/GamePresenter.hpp
@@ -3,6 +3,7 @@
 #include "BoardPresenter.hpp"
 #include "ChatPresenter.hpp"
 #include "gui/gameWidget.hpp"
+#include "tengen/IChatSession.hpp"
 #include "tengen/IGameSession.hpp"
 
 #include <memory>
@@ -11,7 +12,7 @@ namespace tengen {
 
 class GamePresenter : public app::IAppSignalListener {
 public:
-	GamePresenter(app::IGameSession& game, gui::GameWidget& gameWidget);
+	GamePresenter(app::IGameSession& game, app::IChatSession* chat, gui::GameWidget& gameWidget);
 	~GamePresenter() override;
 
 	void onAppEvent(app::AppSignal signal) override; //!< Called by the game thread. Ensure not blocking.
@@ -20,6 +21,8 @@ public:
 
 private:
 	app::IGameSession& m_game;
+	app::IChatSession* m_chat{nullptr};
+
 	gui::GameWidget& m_gameWidget;
 	std::unique_ptr<BoardPresenter> m_boardPresenter = nullptr;
 	std::unique_ptr<ChatPresenter> m_chatPresenter   = nullptr;

--- a/src/apps/tengen/GamePresenter.hpp
+++ b/src/apps/tengen/GamePresenter.hpp
@@ -6,11 +6,15 @@
 #include "tengen/IChatSession.hpp"
 #include "tengen/IGameSession.hpp"
 
+#include <QObject>
+
 #include <memory>
 
 namespace tengen {
 
-class GamePresenter : public app::IAppSignalListener {
+class GamePresenter : public QObject, public app::IAppSignalListener {
+	Q_OBJECT
+
 public:
 	GamePresenter(app::IGameSession& game, gui::GameWidget& gameWidget);
 	~GamePresenter() override;
@@ -18,8 +22,10 @@ public:
 	void addChatWindow(app::IChatSession& chat);
 
 	void onAppEvent(app::AppSignal signal) override; //!< Called by the game thread. Ensure not blocking.
-	void onPassRequested();                          //!< Handle pass event from Board Widget.
-	void onResignRequested();                        //!< Handle resign event from Board Widget.
+
+private slots:
+	void onPassRequested();   //!< Handle pass event from Board Widget.
+	void onResignRequested(); //!< Handle resign event from Board Widget.
 
 private:
 	app::IGameSession& m_game;

--- a/src/apps/tengen/MainWindowPresenter.cpp
+++ b/src/apps/tengen/MainWindowPresenter.cpp
@@ -10,8 +10,6 @@ MainWindowPresenter::MainWindowPresenter(gui::MainWindow& mainWindow) : m_mainWi
 	QObject::connect(&m_mainWindow, &gui::MainWindow::connectRequested, &m_mainWindow, [this](const QString& hostIp) { onConnectRequested(hostIp.toStdString()); });
 	QObject::connect(&m_mainWindow, &gui::MainWindow::hostRequested, &m_mainWindow, [this](const unsigned boardSize) { onHostRequested(boardSize); });
 	QObject::connect(&m_mainWindow, &gui::MainWindow::shutdownRequested, &m_mainWindow, [this]() { onShutdownRequested(); });
-
-	m_gamePresenter = std::make_unique<GamePresenter>(m_game, m_mainWindow.gameWidget());
 }
 
 MainWindowPresenter::~MainWindowPresenter() = default;
@@ -24,6 +22,9 @@ void MainWindowPresenter::onConnectRequested(const std::string& hostIp) {
 
     m_game = std::make_unique<app::NetworkSession>();
     m_game->connect(hostIp);
+
+    m_gamePresenter = std::make_unique<GamePresenter>(m_game, m_mainWindow.gameWidget());
+    m_gamePresenter->addChatWindow(*m_game.get());
 }
 
 void MainWindowPresenter::onHostRequested(const unsigned boardSize) {
@@ -34,10 +35,15 @@ void MainWindowPresenter::onHostRequested(const unsigned boardSize) {
 
     m_game = std::make_unique<app::NetworkSession>();
     m_game->host(boardSize);
+
+    m_gamePresenter = std::make_unique<GamePresenter>(m_game, m_mainWindow.gameWidget());
+    m_gamePresenter->addChatWindow(*m_game.get());
 }
 
 void MainWindowPresenter::onShutdownRequested() {
     if(m_game){
+        m_gamePresenter = nullptr; // Destroy before m_game
+
         m_game->shutdown();
         m_game = nullptr;
     }

--- a/src/apps/tengen/MainWindowPresenter.cpp
+++ b/src/apps/tengen/MainWindowPresenter.cpp
@@ -1,8 +1,11 @@
 #include "MainWindowPresenter.hpp"
 
+#include "GamePresenter.hpp"
 #include "tengen/networkSession.hpp"
+#include "tengen/openSession.hpp"
 
 #include <QObject>
+#include <memory>
 
 namespace tengen {
 
@@ -11,15 +14,19 @@ MainWindowPresenter::MainWindowPresenter(gui::MainWindow& mainWindow) : m_mainWi
 	                 [this](const QString& hostIp) { onConnectRequested(hostIp.toStdString()); });
 	QObject::connect(&m_mainWindow, &gui::MainWindow::hostRequested, &m_mainWindow, [this](const unsigned boardSize) { onHostRequested(boardSize); });
 	QObject::connect(&m_mainWindow, &gui::MainWindow::shutdownRequested, &m_mainWindow, [this]() { onShutdownRequested(); });
+
+	startOpenPlay();
 }
 
 MainWindowPresenter::~MainWindowPresenter() = default;
 
+void MainWindowPresenter::startOpenPlay() {
+	m_game          = std::make_unique<app::OpenSession>(9u);
+	m_gamePresenter = std::make_unique<GamePresenter>(*m_game, m_mainWindow.gameWidget());
+}
+
 void MainWindowPresenter::onConnectRequested(const std::string& hostIp) {
-	if (m_game) {
-		// Session already in progress
-		return;
-	}
+	onShutdownRequested();
 
 	auto session = std::make_unique<app::NetworkSession>();
 	session->connect(hostIp);
@@ -32,10 +39,7 @@ void MainWindowPresenter::onConnectRequested(const std::string& hostIp) {
 }
 
 void MainWindowPresenter::onHostRequested(const unsigned boardSize) {
-	if (m_game) {
-		// Session already in progress
-		return;
-	}
+	onShutdownRequested();
 
 	auto session = std::make_unique<app::NetworkSession>();
 	session->host(boardSize);

--- a/src/apps/tengen/MainWindowPresenter.cpp
+++ b/src/apps/tengen/MainWindowPresenter.cpp
@@ -15,38 +15,43 @@ MainWindowPresenter::MainWindowPresenter(gui::MainWindow& mainWindow) : m_mainWi
 MainWindowPresenter::~MainWindowPresenter() = default;
 
 void MainWindowPresenter::onConnectRequested(const std::string& hostIp) {
-    if(m_game) {
-        // Session already in progress
-        return;
-    }
+	if (m_game) {
+		// Session already in progress
+		return;
+	}
 
-    m_game = std::make_unique<app::NetworkSession>();
-    m_game->connect(hostIp);
+	auto session = std::make_unique<app::NetworkSession>();
+	session->connect(hostIp);
 
-    m_gamePresenter = std::make_unique<GamePresenter>(m_game, m_mainWindow.gameWidget());
-    m_gamePresenter->addChatWindow(*m_game.get());
+	auto& game = static_cast<app::IGameSession&>(*session);
+	auto& chat = static_cast<app::IChatSession&>(*session);
+	m_gamePresenter = std::make_unique<GamePresenter>(game, m_mainWindow.gameWidget());
+	m_gamePresenter->addChatWindow(chat);
+	m_game = std::move(session);
 }
 
 void MainWindowPresenter::onHostRequested(const unsigned boardSize) {
-    if(m_game) {
-        // Session already in progress
-        return;
-    }
+	if (m_game) {
+		// Session already in progress
+		return;
+	}
 
-    m_game = std::make_unique<app::NetworkSession>();
-    m_game->host(boardSize);
+	auto session = std::make_unique<app::NetworkSession>();
+	session->host(boardSize);
 
-    m_gamePresenter = std::make_unique<GamePresenter>(m_game, m_mainWindow.gameWidget());
-    m_gamePresenter->addChatWindow(*m_game.get());
+	auto& game = static_cast<app::IGameSession&>(*session);
+	auto& chat = static_cast<app::IChatSession&>(*session);
+	m_gamePresenter = std::make_unique<GamePresenter>(game, m_mainWindow.gameWidget());
+	m_gamePresenter->addChatWindow(chat);
+	m_game = std::move(session);
 }
 
 void MainWindowPresenter::onShutdownRequested() {
-    if(m_game){
-        m_gamePresenter = nullptr; // Destroy before m_game
-
-        m_game->shutdown();
-        m_game = nullptr;
-    }
+	if (m_game) {
+		m_gamePresenter = nullptr; // Destroy before m_game
+		m_game->shutdown();
+		m_game = nullptr;
+	}
 }
 
 } // namespace tengen

--- a/src/apps/tengen/MainWindowPresenter.cpp
+++ b/src/apps/tengen/MainWindowPresenter.cpp
@@ -7,7 +7,8 @@
 namespace tengen {
 
 MainWindowPresenter::MainWindowPresenter(gui::MainWindow& mainWindow) : m_mainWindow(mainWindow) {
-	QObject::connect(&m_mainWindow, &gui::MainWindow::connectRequested, &m_mainWindow, [this](const QString& hostIp) { onConnectRequested(hostIp.toStdString()); });
+	QObject::connect(&m_mainWindow, &gui::MainWindow::connectRequested, &m_mainWindow,
+	                 [this](const QString& hostIp) { onConnectRequested(hostIp.toStdString()); });
 	QObject::connect(&m_mainWindow, &gui::MainWindow::hostRequested, &m_mainWindow, [this](const unsigned boardSize) { onHostRequested(boardSize); });
 	QObject::connect(&m_mainWindow, &gui::MainWindow::shutdownRequested, &m_mainWindow, [this]() { onShutdownRequested(); });
 }
@@ -23,8 +24,8 @@ void MainWindowPresenter::onConnectRequested(const std::string& hostIp) {
 	auto session = std::make_unique<app::NetworkSession>();
 	session->connect(hostIp);
 
-	auto& game = static_cast<app::IGameSession&>(*session);
-	auto& chat = static_cast<app::IChatSession&>(*session);
+	auto& game      = static_cast<app::IGameSession&>(*session);
+	auto& chat      = static_cast<app::IChatSession&>(*session);
 	m_gamePresenter = std::make_unique<GamePresenter>(game, m_mainWindow.gameWidget());
 	m_gamePresenter->addChatWindow(chat);
 	m_game = std::move(session);
@@ -39,8 +40,8 @@ void MainWindowPresenter::onHostRequested(const unsigned boardSize) {
 	auto session = std::make_unique<app::NetworkSession>();
 	session->host(boardSize);
 
-	auto& game = static_cast<app::IGameSession&>(*session);
-	auto& chat = static_cast<app::IChatSession&>(*session);
+	auto& game      = static_cast<app::IGameSession&>(*session);
+	auto& chat      = static_cast<app::IChatSession&>(*session);
 	m_gamePresenter = std::make_unique<GamePresenter>(game, m_mainWindow.gameWidget());
 	m_gamePresenter->addChatWindow(chat);
 	m_game = std::move(session);

--- a/src/apps/tengen/MainWindowPresenter.cpp
+++ b/src/apps/tengen/MainWindowPresenter.cpp
@@ -1,17 +1,46 @@
 #include "MainWindowPresenter.hpp"
 
+#include "tengen/networkSession.hpp"
+
 #include <QObject>
 
 namespace tengen {
 
 MainWindowPresenter::MainWindowPresenter(gui::MainWindow& mainWindow) : m_mainWindow(mainWindow) {
-	QObject::connect(&m_mainWindow, &gui::MainWindow::connectRequested, &m_mainWindow, [this](const QString& hostIp) { m_game.connect(hostIp.toStdString()); });
-	QObject::connect(&m_mainWindow, &gui::MainWindow::hostRequested, &m_mainWindow, [this](const unsigned boardSize) { m_game.host(boardSize); });
-	QObject::connect(&m_mainWindow, &gui::MainWindow::shutdownRequested, &m_mainWindow, [this]() { m_game.shutdown(); });
+	QObject::connect(&m_mainWindow, &gui::MainWindow::connectRequested, &m_mainWindow, [this](const QString& hostIp) { onConnectRequested(hostIp.toStdString()); });
+	QObject::connect(&m_mainWindow, &gui::MainWindow::hostRequested, &m_mainWindow, [this](const unsigned boardSize) { onHostRequested(boardSize); });
+	QObject::connect(&m_mainWindow, &gui::MainWindow::shutdownRequested, &m_mainWindow, [this]() { onShutdownRequested(); });
 
 	m_gamePresenter = std::make_unique<GamePresenter>(m_game, m_mainWindow.gameWidget());
 }
 
 MainWindowPresenter::~MainWindowPresenter() = default;
+
+void MainWindowPresenter::onConnectRequested(const std::string& hostIp) {
+    if(m_game) {
+        // Session already in progress
+        return;
+    }
+
+    m_game = std::make_unique<app::NetworkSession>();
+    m_game->connect(hostIp);
+}
+
+void MainWindowPresenter::onHostRequested(const unsigned boardSize) {
+    if(m_game) {
+        // Session already in progress
+        return;
+    }
+
+    m_game = std::make_unique<app::NetworkSession>();
+    m_game->host(boardSize);
+}
+
+void MainWindowPresenter::onShutdownRequested() {
+    if(m_game){
+        m_game->shutdown();
+        m_game = nullptr;
+    }
+}
 
 } // namespace tengen

--- a/src/apps/tengen/MainWindowPresenter.hpp
+++ b/src/apps/tengen/MainWindowPresenter.hpp
@@ -2,8 +2,9 @@
 
 #include "GamePresenter.hpp"
 #include "MainWindow.hpp"
-#include "tengen/sessionManager.hpp"
+#include "tengen/IGameSession.hpp"
 
+#include <string>
 #include <memory>
 
 namespace tengen {
@@ -13,9 +14,14 @@ public:
 	explicit MainWindowPresenter(gui::MainWindow& mainWindow);
 	~MainWindowPresenter();
 
+private: // slots
+    void onConnectRequested(const std::string& hostIp);
+    void onHostRequested(const unsigned boardSize);
+    void onShutdownRequested();
+
 private:
 	gui::MainWindow& m_mainWindow;
-	app::SessionManager m_game;
+	std::unique_ptr<app::IGameSession> m_game;
 	std::unique_ptr<GamePresenter> m_gamePresenter = nullptr;
 };
 

--- a/src/apps/tengen/MainWindowPresenter.hpp
+++ b/src/apps/tengen/MainWindowPresenter.hpp
@@ -4,8 +4,8 @@
 #include "MainWindow.hpp"
 #include "tengen/IGameSession.hpp"
 
-#include <string>
 #include <memory>
+#include <string>
 
 namespace tengen {
 
@@ -15,9 +15,9 @@ public:
 	~MainWindowPresenter();
 
 private: // slots
-    void onConnectRequested(const std::string& hostIp);
-    void onHostRequested(const unsigned boardSize);
-    void onShutdownRequested();
+	void onConnectRequested(const std::string& hostIp);
+	void onHostRequested(const unsigned boardSize);
+	void onShutdownRequested();
 
 private:
 	gui::MainWindow& m_mainWindow;

--- a/src/apps/tengen/MainWindowPresenter.hpp
+++ b/src/apps/tengen/MainWindowPresenter.hpp
@@ -20,6 +20,9 @@ private: // slots
 	void onShutdownRequested();
 
 private:
+	void startOpenPlay();
+
+private:
 	gui::MainWindow& m_mainWindow;
 	std::unique_ptr<app::IGameSession> m_game{nullptr};
 	std::unique_ptr<GamePresenter> m_gamePresenter{nullptr};

--- a/src/apps/tengen/MainWindowPresenter.hpp
+++ b/src/apps/tengen/MainWindowPresenter.hpp
@@ -21,8 +21,8 @@ private: // slots
 
 private:
 	gui::MainWindow& m_mainWindow;
-	std::unique_ptr<app::IGameSession> m_game;
-	std::unique_ptr<GamePresenter> m_gamePresenter = nullptr;
+	std::unique_ptr<app::IGameSession> m_game{nullptr};
+	std::unique_ptr<GamePresenter> m_gamePresenter{nullptr};
 };
 
 } // namespace tengen

--- a/src/game/core/include/core/game.hpp
+++ b/src/game/core/include/core/game.hpp
@@ -17,7 +17,7 @@ using EventQueue = SafeQueue<GameEvent>;
 class Game {
 public:
 	//! Setup a game of certain board size without starting the game loop.
-	Game(std::size_t boardSize);
+	Game(std::size_t boardSize); // TODO: Will be extended to take a game configuration(timer type, board size, ruleset, etc).
 
 	void run();                      //!< Run the main game loop/start handling the event loop (blocking).
 	void pushEvent(GameEvent event); //!< Push an event to the event queue.

--- a/src/game/gui/CMakeLists.txt
+++ b/src/game/gui/CMakeLists.txt
@@ -33,10 +33,15 @@ target_link_libraries(${targetName}
         Qt6::Widgets
 )
 
-set_target_properties(${targetName} PROPERTIES AUTOMOC ON) # Auto handling of QT Meta-Object Compiler
-target_compile_definitions(${targetName} PRIVATE TEXTURE_BLACK="${CMAKE_SOURCE_DIR}/assets/anime_black.png")
-target_compile_definitions(${targetName} PRIVATE TEXTURE_WHITE="${CMAKE_SOURCE_DIR}/assets/anime_white.png")
-
+set_target_properties(${targetName}
+    PROPERTIES
+        AUTOMOC ON # Auto handling of QT Meta-Object Compiler
+)
+target_compile_definitions(${targetName}
+    PRIVATE
+        TEXTURE_BLACK="${CMAKE_SOURCE_DIR}/assets/anime_black.png"
+        TEXTURE_WHITE="${CMAKE_SOURCE_DIR}/assets/anime_white.png"
+)
 
 # Setup project settings
 set_target_configuration(${targetName} Config::Default)

--- a/src/game/gui/gameWidget.cpp
+++ b/src/game/gui/gameWidget.cpp
@@ -36,6 +36,19 @@ void GameWidget::setGameStateText(const QString& text) {
 	m_statusLabel->setText(text);
 }
 
+void GameWidget::setChatEnabled(const bool enabled) {
+	if (!m_sideTabs || !m_chatWidget || m_chatTabIndex < 0) {
+		return;
+	}
+
+	if (!enabled && m_sideTabs->currentIndex() == m_chatTabIndex) {
+		m_sideTabs->setCurrentIndex(0);
+	}
+
+	m_sideTabs->setTabEnabled(m_chatTabIndex, enabled);
+	m_chatWidget->setEnabled(enabled);
+}
+
 void GameWidget::buildNetworkLayout() {
 	auto* mainLayout = new QVBoxLayout(this);
 	mainLayout->setContentsMargins(12, 12, 12, 12);
@@ -64,7 +77,7 @@ void GameWidget::buildNetworkLayout() {
 	chatLayout->setContentsMargins(0, 0, 0, 0);
 	m_chatWidget = new ChatWidget(chatTab);
 	chatLayout->addWidget(m_chatWidget, 1);
-	m_sideTabs->addTab(chatTab, "Chat");
+	m_chatTabIndex = m_sideTabs->addTab(chatTab, "Chat");
 
 	contentLayout->addWidget(m_sideTabs, 1);
 	mainLayout->addLayout(contentLayout, 1);

--- a/src/game/gui/include/gui/gameWidget.hpp
+++ b/src/game/gui/include/gui/gameWidget.hpp
@@ -23,6 +23,7 @@ public:
 
 	void setCurrentPlayerText(const QString& text);
 	void setGameStateText(const QString& text);
+	void setChatEnabled(bool enabled);
 
 signals:
 	void passEvent();
@@ -36,6 +37,7 @@ private:
 	BoardWidget* m_boardWidget = nullptr;
 	ChatWidget* m_chatWidget   = nullptr;
 	QTabWidget* m_sideTabs     = nullptr;
+	int m_chatTabIndex         = -1;
 
 	QLabel* m_statusLabel     = nullptr; //!< Game status text (active, finished).
 	QLabel* m_currPlayerLabel = nullptr; //!< Current player text.

--- a/src/game/runtime/CMakeLists.txt
+++ b/src/game/runtime/CMakeLists.txt
@@ -4,8 +4,9 @@ set(targetName gameRuntime)
 
 # Get files to build
 set(headers
-    "${CMAKE_CURRENT_LIST_DIR}/include/tengen/sessionManager.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/tengen/networkSession.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IAppSignalListener.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IGameSession.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/eventHub.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/position.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/gameServer.hpp"
@@ -13,7 +14,7 @@ set(headers
 )
 
 set(sources
-    "${CMAKE_CURRENT_LIST_DIR}/sessionManager.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/networkSession.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/eventHub.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/position.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/gameServer.cpp"

--- a/src/game/runtime/CMakeLists.txt
+++ b/src/game/runtime/CMakeLists.txt
@@ -5,7 +5,7 @@ set(targetName gameRuntime)
 # Get files to build
 set(headers
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/networkSession.hpp"
-    "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IAppSignalListener.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IAppSignal.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IGameSession.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IChatSession.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/eventHub.hpp"

--- a/src/game/runtime/CMakeLists.txt
+++ b/src/game/runtime/CMakeLists.txt
@@ -7,6 +7,7 @@ set(headers
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/networkSession.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IAppSignalListener.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IGameSession.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IChatSession.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/eventHub.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/position.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/gameServer.hpp"

--- a/src/game/runtime/CMakeLists.txt
+++ b/src/game/runtime/CMakeLists.txt
@@ -5,6 +5,7 @@ set(targetName gameRuntime)
 # Get files to build
 set(headers
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/networkSession.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/tengen/openSession.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IAppSignal.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IGameSession.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/tengen/IChatSession.hpp"
@@ -16,6 +17,7 @@ set(headers
 
 set(sources
     "${CMAKE_CURRENT_LIST_DIR}/networkSession.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/openSession.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/eventHub.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/position.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/gameServer.cpp"

--- a/src/game/runtime/include/tengen/IAppSignal.hpp
+++ b/src/game/runtime/include/tengen/IAppSignal.hpp
@@ -16,7 +16,16 @@ enum AppSignal : uint64_t {
 class IAppSignalListener {
 public:
 	virtual ~IAppSignalListener()             = default;
+
 	virtual void onAppEvent(AppSignal signal) = 0;
+};
+
+class IAppSignalSource {
+public:
+    virtual ~IAppSignalSource() = default;
+
+    virtual void subscribe(app::IAppSignalListener* listener, uint64_t mask) = 0;
+    virtual void unsubscribe(app::IAppSignalListener* listener) = 0;
 };
 
 } // namespace tengen::app

--- a/src/game/runtime/include/tengen/IAppSignal.hpp
+++ b/src/game/runtime/include/tengen/IAppSignal.hpp
@@ -15,17 +15,17 @@ enum AppSignal : uint64_t {
 
 class IAppSignalListener {
 public:
-	virtual ~IAppSignalListener()             = default;
+	virtual ~IAppSignalListener() = default;
 
 	virtual void onAppEvent(AppSignal signal) = 0;
 };
 
 class IAppSignalSource {
 public:
-    virtual ~IAppSignalSource() = default;
+	virtual ~IAppSignalSource() = default;
 
-    virtual void subscribe(app::IAppSignalListener* listener, uint64_t mask) = 0;
-    virtual void unsubscribe(app::IAppSignalListener* listener) = 0;
+	virtual void subscribe(app::IAppSignalListener* listener, uint64_t mask) = 0;
+	virtual void unsubscribe(app::IAppSignalListener* listener)              = 0;
 };
 
 } // namespace tengen::app

--- a/src/game/runtime/include/tengen/IChatSession.hpp
+++ b/src/game/runtime/include/tengen/IChatSession.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "tengen/IAppSignalListener.hpp"
+#include "model/player.hpp"
+
+#include <vector>
+#include <string>
+
+namespace tengen::app {
+
+struct ChatEntry {
+	Player player;
+	unsigned messageId;
+	std::string message;
+};
+
+class IChatSession {
+public:
+    virtual ~IChatSession() = default;
+
+    virtual void subscribe(app::IAppSignalListener* listener, uint64_t mask) = 0;
+    virtual void unsubscribe(app::IAppSignalListener* listener) = 0;
+
+    virtual void chat(const std::string& message) = 0;
+    virtual std::vector<ChatEntry> getChatSince(unsigned messageId) const = 0;
+};
+
+}

--- a/src/game/runtime/include/tengen/IChatSession.hpp
+++ b/src/game/runtime/include/tengen/IChatSession.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "tengen/IAppSignal.hpp"
 #include "model/player.hpp"
+#include "tengen/IAppSignal.hpp"
 
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace tengen::app {
 
@@ -16,10 +16,10 @@ struct ChatEntry {
 
 class IChatSession : public IAppSignalSource {
 public:
-    virtual ~IChatSession() = default;
+	virtual ~IChatSession() = default;
 
-    virtual void chat(const std::string& message) = 0;
-    virtual std::vector<ChatEntry> getChatSince(unsigned messageId) const = 0;
+	virtual void chat(const std::string& message)                         = 0;
+	virtual std::vector<ChatEntry> getChatSince(unsigned messageId) const = 0;
 };
 
-}
+} // namespace tengen::app

--- a/src/game/runtime/include/tengen/IChatSession.hpp
+++ b/src/game/runtime/include/tengen/IChatSession.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "tengen/IAppSignalListener.hpp"
+#include "tengen/IAppSignal.hpp"
 #include "model/player.hpp"
 
 #include <vector>
@@ -14,12 +14,9 @@ struct ChatEntry {
 	std::string message;
 };
 
-class IChatSession {
+class IChatSession : public IAppSignalSource {
 public:
     virtual ~IChatSession() = default;
-
-    virtual void subscribe(app::IAppSignalListener* listener, uint64_t mask) = 0;
-    virtual void unsubscribe(app::IAppSignalListener* listener) = 0;
 
     virtual void chat(const std::string& message) = 0;
     virtual std::vector<ChatEntry> getChatSince(unsigned messageId) const = 0;

--- a/src/game/runtime/include/tengen/IGameSession.hpp
+++ b/src/game/runtime/include/tengen/IGameSession.hpp
@@ -1,24 +1,24 @@
 #pragma once
 
-#include "tengen/IAppSignal.hpp"
 #include "model/board.hpp"
 #include "model/gameStatus.hpp"
+#include "tengen/IAppSignal.hpp"
 
 namespace tengen::app {
 
 class IGameSession : public IAppSignalSource {
 public:
-    virtual ~IGameSession() = default;
+	virtual ~IGameSession() = default;
 
-    virtual GameStatus status() const = 0;
-    virtual Board board() const = 0;
-    virtual Player currentPlayer() const = 0;
+	virtual GameStatus status() const    = 0;
+	virtual Board board() const          = 0;
+	virtual Player currentPlayer() const = 0;
 
-    virtual void tryPlace(unsigned x, unsigned y) = 0;
-    virtual void tryPass() = 0;
-    virtual void tryResign() = 0;
-    virtual void shutdown() = 0;
+	virtual void tryPlace(unsigned x, unsigned y) = 0;
+	virtual void tryPass()                        = 0;
+	virtual void tryResign()                      = 0;
+	virtual void shutdown()                       = 0;
 };
 
 
-}
+} // namespace tengen::app

--- a/src/game/runtime/include/tengen/IGameSession.hpp
+++ b/src/game/runtime/include/tengen/IGameSession.hpp
@@ -1,17 +1,14 @@
 #pragma once
 
-#include "tengen/IAppSignalListener.hpp"
+#include "tengen/IAppSignal.hpp"
 #include "model/board.hpp"
 #include "model/gameStatus.hpp"
 
 namespace tengen::app {
 
-class IGameSession {
+class IGameSession : public IAppSignalSource {
 public:
     virtual ~IGameSession() = default;
-
-    virtual void subscribe(app::IAppSignalListener* listener, uint64_t mask) = 0;
-    virtual void unsubscribe(app::IAppSignalListener* listener) = 0;
 
     virtual GameStatus status() const = 0;
     virtual Board board() const = 0;

--- a/src/game/runtime/include/tengen/IGameSession.hpp
+++ b/src/game/runtime/include/tengen/IGameSession.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "tengen/IAppSignalListener.hpp"
+#include "model/board.hpp"
+#include "model/gameStatus.hpp"
+
+namespace tengen::app {
+
+class IGameSession {
+public:
+    virtual ~IGameSession() = default;
+
+    virtual void subscribe(app::IAppSignalListener* listener, uint64_t mask) = 0;
+    virtual void unsubscribe(app::IAppSignalListener* listener) = 0;
+
+    virtual GameStatus status() const = 0;
+    virtual Board board() const = 0;
+    virtual Player currentPlayer() const = 0;
+
+    virtual void tryPlace(unsigned x, unsigned y) = 0;
+    virtual void tryPass() = 0;
+    virtual void tryResign() = 0;
+    virtual void shutdown() = 0;
+};
+
+
+}

--- a/src/game/runtime/include/tengen/eventHub.hpp
+++ b/src/game/runtime/include/tengen/eventHub.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "IAppSignalListener.hpp"
+#include "IAppSignal.hpp"
 
 #include <mutex>
 #include <vector>

--- a/src/game/runtime/include/tengen/networkSession.hpp
+++ b/src/game/runtime/include/tengen/networkSession.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "tengen/IChatSession.hpp"
 #include "tengen/IGameSession.hpp"
 #include "network/client.hpp"
 #include "tengen/IAppSignalListener.hpp"
@@ -10,22 +11,15 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 namespace tengen::app {
 class GameServer;
-
-struct ChatEntry {
-	Player player;
-	unsigned messageId;
-	std::string message;
-};
 
 //! Gets game stat delta and constructs a local representation of the game.
 //! Listeners can subscribe to certain signals, get notification when happens.
 //! Listeners then check which signal and query the updated data from this NetworkSession.
 //! NetworkSession is the local source of truth about the game state, GUI is just dumb renderer of this state.
-class NetworkSession : public network::IClientHandler, public IGameSession {
+class NetworkSession : public network::IClientHandler, public IGameSession, public IChatSession {
 public:
 	NetworkSession();
 	~NetworkSession();
@@ -51,9 +45,10 @@ public:
 	void connect(const std::string& hostIp);
 	void host(unsigned boardSize);
 	void disconnect();
-	void chat(const std::string& message);
 
-	std::vector<ChatEntry> getChatSince(unsigned messageId) const;
+	// Chat
+	void chat(const std::string& message) override;
+	std::vector<ChatEntry> getChatSince(unsigned messageId) const override;
 
 public: // Client listener handlers
 	void onGameUpdate(const network::ServerDelta& event) override;

--- a/src/game/runtime/include/tengen/networkSession.hpp
+++ b/src/game/runtime/include/tengen/networkSession.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "tengen/IChatSession.hpp"
-#include "tengen/IGameSession.hpp"
 #include "network/client.hpp"
 #include "tengen/IAppSignal.hpp"
+#include "tengen/IChatSession.hpp"
+#include "tengen/IGameSession.hpp"
 #include "tengen/eventHub.hpp"
 #include "tengen/position.hpp"
 

--- a/src/game/runtime/include/tengen/networkSession.hpp
+++ b/src/game/runtime/include/tengen/networkSession.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "tengen/IGameSession.hpp"
 #include "network/client.hpp"
 #include "tengen/IAppSignalListener.hpp"
 #include "tengen/eventHub.hpp"
@@ -22,35 +23,36 @@ struct ChatEntry {
 
 //! Gets game stat delta and constructs a local representation of the game.
 //! Listeners can subscribe to certain signals, get notification when happens.
-//! Listeners then check which signal and query the updated data from this SessionManager.
-//! SessionManager is the local source of truth about the game state, GUI is just dumb renderer of this state.
-class SessionManager : public network::IClientHandler {
+//! Listeners then check which signal and query the updated data from this NetworkSession.
+//! NetworkSession is the local source of truth about the game state, GUI is just dumb renderer of this state.
+class NetworkSession : public network::IClientHandler, public IGameSession {
 public:
-	SessionManager();
-	~SessionManager();
+	NetworkSession();
+	~NetworkSession();
 
-	void subscribe(IAppSignalListener* listener, uint64_t signalMask);
-	void unsubscribe(IAppSignalListener* listener);
+	void subscribe(IAppSignalListener* listener, uint64_t signalMask) override;
+	void unsubscribe(IAppSignalListener* listener) override;
 
+	// TODO: Maybe the UI elements should have a const reference to 'Position'. (Position is data layer; NetworkSession is application layer)
+	//       Then position only has public getters and NetworkSession is a friend so it can update.
+	//       Then we could remove these getters.
+	//       NetworkSession updates Position. Position emits signals. Listeners query position for new data.
+	// Getters
+	GameStatus status() const override;
+	Board board() const override;
+	Player currentPlayer() const override;
+
+	void tryPlace(unsigned x, unsigned y) override;
+	void tryResign() override;
+	void tryPass() override;
+	void shutdown() override;
+
+	// Network interface
 	void connect(const std::string& hostIp);
 	void host(unsigned boardSize);
 	void disconnect();
-	void shutdown();
-
-	// Setters
-	void tryPlace(unsigned x, unsigned y);
-	void tryResign();
-	void tryPass();
 	void chat(const std::string& message);
 
-	// TODO: Maybe the UI elements should have a const reference to 'Position'. (Position is data layer; SessionManager is application layer)
-	//       Then position only has public getters and SessionManager is a friend so it can update.
-	//       Then we could remove these getters.
-	//       SessionManager updates Position. Position emits signals. Listeners query position for new data.
-	// Getters
-	GameStatus status() const;
-	Board board() const;
-	Player currentPlayer() const;
 	std::vector<ChatEntry> getChatSince(unsigned messageId) const;
 
 public: // Client listener handlers

--- a/src/game/runtime/include/tengen/networkSession.hpp
+++ b/src/game/runtime/include/tengen/networkSession.hpp
@@ -3,7 +3,7 @@
 #include "tengen/IChatSession.hpp"
 #include "tengen/IGameSession.hpp"
 #include "network/client.hpp"
-#include "tengen/IAppSignalListener.hpp"
+#include "tengen/IAppSignal.hpp"
 #include "tengen/eventHub.hpp"
 #include "tengen/position.hpp"
 

--- a/src/game/runtime/include/tengen/openSession.hpp
+++ b/src/game/runtime/include/tengen/openSession.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "core/IGameStateListener.hpp"
+#include "core/game.hpp"
+#include "tengen/IGameSession.hpp"
+#include "tengen/eventHub.hpp"
+
+#include <mutex>
+#include <thread>
+
+namespace tengen::app {
+
+//! Free play locally you control both players.
+class OpenSession : public IGameSession, public IGameStateListener {
+public:
+	OpenSession(std::size_t boardSize);
+	~OpenSession() override;
+
+	// GameSession Interface
+	GameStatus status() const override;
+	Board board() const override;
+	Player currentPlayer() const override;
+
+	void tryPlace(unsigned x, unsigned y) override;
+	void tryPass() override;
+	void tryResign() override;
+	void shutdown() override;
+
+	// AppSignal Handlers
+	void subscribe(app::IAppSignalListener* listener, uint64_t mask) override;
+	void unsubscribe(app::IAppSignalListener* listener) override;
+
+	// Game Handlers
+	void onGameDelta(const GameDelta& delta) override;
+
+private:
+	Game m_game;
+	EventHub m_eventHub;
+
+	std::thread m_gameThread; //!< Runs the game loop.
+	mutable std::mutex m_stateMutex;
+
+	// TODO: Position class should not be server dependent.
+	//       Then we can reuse it here.
+	// Game State
+	Board m_board;
+	Player m_currentPlayer{Player::Black};
+	GameStatus m_status{GameStatus::Active};
+};
+
+} // namespace tengen::app

--- a/src/game/runtime/include/tengen/openSession.hpp
+++ b/src/game/runtime/include/tengen/openSession.hpp
@@ -4,6 +4,7 @@
 #include "core/game.hpp"
 #include "tengen/IGameSession.hpp"
 #include "tengen/eventHub.hpp"
+#include "tengen/position.hpp"
 
 #include <mutex>
 #include <thread>
@@ -40,12 +41,7 @@ private:
 	std::thread m_gameThread; //!< Runs the game loop.
 	mutable std::mutex m_stateMutex;
 
-	// TODO: Position class should not be server dependent.
-	//       Then we can reuse it here.
-	// Game State
-	Board m_board;
-	Player m_currentPlayer{Player::Black};
-	GameStatus m_status{GameStatus::Active};
+	Position m_position{};
 };
 
 } // namespace tengen::app

--- a/src/game/runtime/include/tengen/position.hpp
+++ b/src/game/runtime/include/tengen/position.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "core/gameEvent.hpp"
 #include "model/board.hpp"
 #include "model/gameStatus.hpp"
 #include "model/player.hpp"
-#include "network/nwEvents.hpp"
 
 namespace tengen::app {
 
@@ -11,17 +11,19 @@ class Position {
 public:
 	Position() = default;
 
-	void reset(std::size_t boardSize);                 //!< Reset the position to some default data.
-	bool init(const network::ServerGameConfig& event); //!< Initialize the given position. Returns true if it changed state.
-	bool apply(const network::ServerDelta& delta);     //!< Apply a delta to the current position if ok.
-	void setStatus(GameStatus status);                 //!< Update the status.
+	void reset(std::size_t boardSize); //!< Reset the position to some default data.
+
+	// TODO: This init will become GameConfig onece we handle Rulesets, clock type, etc.
+	bool init(const std::size_t boardSize); //!< Initialize the given position. Returns true if it changed state.
+	bool apply(const GameDelta& delta);     //!< Apply a delta to the current position if ok.
+	void setStatus(GameStatus status);      //!< Update the status.
 
 	const Board& getBoard() const;
 	GameStatus getStatus() const;
 	Player getPlayer() const;
 
 private:
-	bool isDeltaApplicable(const network::ServerDelta& delta); //!< Check if the delta is ok to use for the position update.
+	bool isDeltaApplicable(const GameDelta& delta); //!< Check if the delta is ok to use for the position update.
 
 private:
 	unsigned m_moveId{0};                  //!< Last move id in game.

--- a/src/game/runtime/networkSession.cpp
+++ b/src/game/runtime/networkSession.cpp
@@ -1,4 +1,4 @@
-#include "tengen/sessionManager.hpp"
+#include "tengen/networkSession.hpp"
 
 #include "logging.hpp"
 #include "tengen/gameServer.hpp"
@@ -8,23 +8,23 @@
 
 namespace tengen::app {
 
-SessionManager::SessionManager() {
+NetworkSession::NetworkSession() {
 	m_network.registerHandler(this);
 }
-SessionManager::~SessionManager() {
+NetworkSession::~NetworkSession() {
 	disconnect();
 }
 
-void SessionManager::subscribe(IAppSignalListener* listener, uint64_t signalMask) {
+void NetworkSession::subscribe(IAppSignalListener* listener, uint64_t signalMask) {
 	m_eventHub.subscribe(listener, signalMask);
 }
 
-void SessionManager::unsubscribe(IAppSignalListener* listener) {
+void NetworkSession::unsubscribe(IAppSignalListener* listener) {
 	m_eventHub.unsubscribe(listener);
 }
 
 
-void SessionManager::connect(const std::string& hostIp) {
+void NetworkSession::connect(const std::string& hostIp) {
 	{
 		std::lock_guard<std::mutex> lock(m_stateMutex);
 		m_position.reset(9u);
@@ -41,7 +41,7 @@ void SessionManager::connect(const std::string& hostIp) {
 	m_eventHub.signal(AS_StateChange);
 }
 
-void SessionManager::host(unsigned boardSize) {
+void NetworkSession::host(unsigned boardSize) {
 	disconnect();
 
 	{
@@ -62,7 +62,7 @@ void SessionManager::host(unsigned boardSize) {
 	m_eventHub.signal(AS_StateChange);
 }
 
-void SessionManager::disconnect() {
+void NetworkSession::disconnect() {
 	m_network.disconnect();
 	if (m_localServer) {
 		m_localServer->stop();
@@ -82,7 +82,7 @@ void SessionManager::disconnect() {
 	m_eventHub.signal(AS_StateChange);
 }
 
-void SessionManager::shutdown() {
+void NetworkSession::shutdown() {
 	if (m_localServer) {
 		m_localServer->stop();
 		m_localServer.reset();
@@ -99,32 +99,32 @@ void SessionManager::shutdown() {
 }
 
 
-void SessionManager::tryPlace(unsigned x, unsigned y) {
+void NetworkSession::tryPlace(unsigned x, unsigned y) {
 	m_network.send(network::ClientPutStone{.c = {x, y}});
 }
-void SessionManager::tryResign() {
+void NetworkSession::tryResign() {
 	m_network.send(network::ClientResign{});
 }
-void SessionManager::tryPass() {
+void NetworkSession::tryPass() {
 	m_network.send(network::ClientPass{});
 }
-void SessionManager::chat(const std::string& message) {
+void NetworkSession::chat(const std::string& message) {
 	m_network.send(network::ClientChat{message});
 }
 
-GameStatus SessionManager::status() const {
+GameStatus NetworkSession::status() const {
 	std::lock_guard<std::mutex> lock(m_stateMutex);
 	return m_position.getStatus();
 }
-Board SessionManager::board() const {
+Board NetworkSession::board() const {
 	std::lock_guard<std::mutex> lock(m_stateMutex);
 	return m_position.getBoard();
 }
-Player SessionManager::currentPlayer() const {
+Player NetworkSession::currentPlayer() const {
 	std::lock_guard<std::mutex> lock(m_stateMutex);
 	return m_position.getPlayer();
 }
-std::vector<ChatEntry> SessionManager::getChatSince(const unsigned messageId) const {
+std::vector<ChatEntry> NetworkSession::getChatSince(const unsigned messageId) const {
 	std::lock_guard<std::mutex> lock(m_stateMutex);
 
 	// Find first entry with id > messageId
@@ -134,7 +134,7 @@ std::vector<ChatEntry> SessionManager::getChatSince(const unsigned messageId) co
 	return {it, m_chatHistory.end()};
 }
 
-void SessionManager::onGameUpdate(const network::ServerDelta& event) {
+void NetworkSession::onGameUpdate(const network::ServerDelta& event) {
 	GameStatus status         = GameStatus::Active;
 	GameStatus previousStatus = GameStatus::Active;
 	bool applied              = false;
@@ -168,7 +168,7 @@ void SessionManager::onGameUpdate(const network::ServerDelta& event) {
 		m_eventHub.signal(AS_StateChange);
 	}
 }
-void SessionManager::onGameConfig(const network::ServerGameConfig& event) {
+void NetworkSession::onGameConfig(const network::ServerGameConfig& event) {
 	bool initialized = false;
 	{
 		std::lock_guard<std::mutex> lock(m_stateMutex);
@@ -181,7 +181,7 @@ void SessionManager::onGameConfig(const network::ServerGameConfig& event) {
 	m_eventHub.signal(AS_PlayerChange);
 	m_eventHub.signal(AS_StateChange);
 }
-void SessionManager::onChatMessage(const network::ServerChat& event) {
+void NetworkSession::onChatMessage(const network::ServerChat& event) {
 	bool appended = false;
 	{
 		std::lock_guard<std::mutex> lock(m_stateMutex);
@@ -212,7 +212,7 @@ void SessionManager::onChatMessage(const network::ServerChat& event) {
 		m_eventHub.signal(AS_NewChat);
 	}
 }
-void SessionManager::onDisconnected() {
+void NetworkSession::onDisconnected() {
 	{
 		std::lock_guard<std::mutex> lock(m_stateMutex);
 		m_position.reset(9u);

--- a/src/game/runtime/networkSession.cpp
+++ b/src/game/runtime/networkSession.cpp
@@ -1,12 +1,40 @@
 #include "tengen/networkSession.hpp"
 
+#include "core/gameEvent.hpp"
 #include "logging.hpp"
+#include "network/types.hpp"
 #include "tengen/gameServer.hpp"
 
 #include <algorithm>
 #include <cassert>
 
 namespace tengen::app {
+
+// TODO: Don't like this copying. Find better way.
+GameDelta toGameDelta(const network::ServerDelta& event) {
+	GameAction action = GameAction::Place;
+	switch (event.action) {
+	case network::ServerAction::Place:
+		action = GameAction::Place;
+		break;
+	case network::ServerAction::Pass:
+		action = GameAction::Pass;
+		break;
+	case network::ServerAction::Resign:
+		action = GameAction::Resign;
+		break;
+	default:
+		assert(false);
+	}
+
+	return {.moveId     = event.turn,
+	        .action     = action,
+	        .player     = event.seat == network::Seat::Black ? Player::Black : Player::White,
+	        .coord      = event.coord,
+	        .captures   = event.captures,
+	        .nextPlayer = event.next == network::Seat::Black ? Player::Black : Player::White,
+	        .gameActive = event.status == network::GameStatus::Active};
+}
 
 NetworkSession::NetworkSession() {
 	m_network.registerHandler(this);
@@ -135,13 +163,20 @@ std::vector<ChatEntry> NetworkSession::getChatSince(const unsigned messageId) co
 }
 
 void NetworkSession::onGameUpdate(const network::ServerDelta& event) {
+	// Player values valid
+	if (!network::isPlayer(event.seat) || !network::isPlayer(event.next)) {
+		Logger().Log(Logging::LogLevel::Error, "Received game update from non player seat.");
+		return;
+	}
+
+	// Update Position
 	GameStatus status         = GameStatus::Active;
 	GameStatus previousStatus = GameStatus::Active;
 	bool applied              = false;
 	{
 		std::lock_guard<std::mutex> lock(m_stateMutex);
 		previousStatus = m_position.getStatus();
-		applied        = m_position.apply(event);
+		applied        = m_position.apply(toGameDelta(event));
 		status         = m_position.getStatus(); // For signalling later
 	}
 
@@ -172,7 +207,7 @@ void NetworkSession::onGameConfig(const network::ServerGameConfig& event) {
 	bool initialized = false;
 	{
 		std::lock_guard<std::mutex> lock(m_stateMutex);
-		initialized = m_position.init(event);
+		initialized = m_position.init(event.boardSize);
 	}
 	if (!initialized) {
 		return;

--- a/src/game/runtime/openSession.cpp
+++ b/src/game/runtime/openSession.cpp
@@ -4,7 +4,8 @@
 
 namespace tengen::app {
 
-OpenSession::OpenSession(const std::size_t boardSize) : m_game(boardSize), m_board(boardSize) {
+OpenSession::OpenSession(const std::size_t boardSize) : m_game(boardSize) {
+	m_position.init(boardSize);
 	m_game.subscribeState(this);
 	m_gameThread = std::thread([this] { m_game.run(); });
 }
@@ -15,15 +16,15 @@ OpenSession::~OpenSession() {
 
 GameStatus OpenSession::status() const {
 	std::lock_guard<std::mutex> lock(m_stateMutex);
-	return m_status;
+	return m_position.getStatus();
 }
 Board OpenSession::board() const {
 	std::lock_guard<std::mutex> lock(m_stateMutex);
-	return m_board;
+	return m_position.getBoard();
 }
 Player OpenSession::currentPlayer() const {
 	std::lock_guard<std::mutex> lock(m_stateMutex);
-	return m_currentPlayer;
+	return m_position.getPlayer();
 }
 
 void OpenSession::tryPlace(const unsigned x, const unsigned y) {
@@ -52,26 +53,32 @@ void OpenSession::unsubscribe(IAppSignalListener* listener) {
 }
 
 void OpenSession::onGameDelta(const GameDelta& delta) {
+	GameStatus status         = GameStatus::Active;
 	GameStatus previousStatus = GameStatus::Active;
+	bool applied              = false;
 	{
 		std::lock_guard<std::mutex> lock(m_stateMutex);
-		previousStatus  = m_status;
-		m_currentPlayer = delta.nextPlayer;
-		m_status        = delta.gameActive ? GameStatus::Active : GameStatus::Done;
-
-		if (delta.action == GameAction::Place && delta.coord) {
-			m_board.place(*delta.coord, toStone(delta.player));
-			for (const auto capture: delta.captures) {
-				m_board.remove(capture);
-			}
-		}
+		previousStatus = m_position.getStatus();
+		applied        = m_position.apply(delta);
+		status         = m_position.getStatus();
 	}
 
-	if (delta.action == GameAction::Place) {
+	if (!applied) {
+		return;
+	}
+
+	switch (delta.action) {
+	case GameAction::Place:
 		m_eventHub.signal(AS_BoardChange);
+		m_eventHub.signal(AS_PlayerChange);
+		break;
+	case GameAction::Pass:
+		m_eventHub.signal(AS_PlayerChange);
+		break;
+	case GameAction::Resign:
+		break;
 	}
-	m_eventHub.signal(AS_PlayerChange);
-	if (previousStatus != m_status) {
+	if (previousStatus != status) {
 		m_eventHub.signal(AS_StateChange);
 	}
 }

--- a/src/game/runtime/openSession.cpp
+++ b/src/game/runtime/openSession.cpp
@@ -1,0 +1,79 @@
+#include "tengen/openSession.hpp"
+
+#include "core/gameEvent.hpp"
+
+namespace tengen::app {
+
+OpenSession::OpenSession(const std::size_t boardSize) : m_game(boardSize), m_board(boardSize) {
+	m_game.subscribeState(this);
+	m_gameThread = std::thread([this] { m_game.run(); });
+}
+
+OpenSession::~OpenSession() {
+	shutdown();
+}
+
+GameStatus OpenSession::status() const {
+	std::lock_guard<std::mutex> lock(m_stateMutex);
+	return m_status;
+}
+Board OpenSession::board() const {
+	std::lock_guard<std::mutex> lock(m_stateMutex);
+	return m_board;
+}
+Player OpenSession::currentPlayer() const {
+	std::lock_guard<std::mutex> lock(m_stateMutex);
+	return m_currentPlayer;
+}
+
+void OpenSession::tryPlace(const unsigned x, const unsigned y) {
+	m_game.pushEvent(PutStoneEvent{currentPlayer(), Coord{x, y}});
+}
+void OpenSession::tryPass() {
+	m_game.pushEvent(PassEvent{currentPlayer()});
+}
+void OpenSession::tryResign() {
+	m_game.pushEvent(ResignEvent{});
+}
+void OpenSession::shutdown() {
+	m_game.pushEvent(ShutdownEvent{});
+	if (m_gameThread.joinable()) {
+		m_gameThread.join();
+	}
+	m_game.unsubscribeState(this);
+}
+
+void OpenSession::subscribe(IAppSignalListener* listener, uint64_t signalMask) {
+	m_eventHub.subscribe(listener, signalMask);
+}
+
+void OpenSession::unsubscribe(IAppSignalListener* listener) {
+	m_eventHub.unsubscribe(listener);
+}
+
+void OpenSession::onGameDelta(const GameDelta& delta) {
+	GameStatus previousStatus = GameStatus::Active;
+	{
+		std::lock_guard<std::mutex> lock(m_stateMutex);
+		previousStatus  = m_status;
+		m_currentPlayer = delta.nextPlayer;
+		m_status        = delta.gameActive ? GameStatus::Active : GameStatus::Done;
+
+		if (delta.action == GameAction::Place && delta.coord) {
+			m_board.place(*delta.coord, toStone(delta.player));
+			for (const auto capture: delta.captures) {
+				m_board.remove(capture);
+			}
+		}
+	}
+
+	if (delta.action == GameAction::Place) {
+		m_eventHub.signal(AS_BoardChange);
+	}
+	m_eventHub.signal(AS_PlayerChange);
+	if (previousStatus != m_status) {
+		m_eventHub.signal(AS_StateChange);
+	}
+}
+
+} // namespace tengen::app

--- a/src/game/runtime/position.cpp
+++ b/src/game/runtime/position.cpp
@@ -12,7 +12,7 @@ void Position::reset(const std::size_t boardSize) {
 	m_board  = Board{boardSize};
 }
 
-bool Position::init(const network::ServerGameConfig& event) {
+bool Position::init(const std::size_t boardSize) {
 	if (m_status == GameStatus::Active) {
 		return false;
 	}
@@ -21,24 +21,24 @@ bool Position::init(const network::ServerGameConfig& event) {
 	m_moveId = 0u;
 	m_status = GameStatus::Active;
 	m_player = Player::Black;
-	m_board  = Board{event.boardSize};
+	m_board  = Board{boardSize};
 	return true;
 }
 
-bool Position::apply(const network::ServerDelta& delta) {
+bool Position::apply(const GameDelta& delta) {
 	if (!isDeltaApplicable(delta)) {
 		return false;
 	}
 
-	m_moveId = delta.turn;
-	m_status = delta.status == network::GameStatus::Active ? GameStatus::Active : GameStatus::Done;
-	m_player = delta.next == network::Seat::Black ? Player::Black : Player::White;
+	m_moveId = delta.moveId;
+	m_status = delta.gameActive ? GameStatus::Active : GameStatus::Done;
+	m_player = delta.nextPlayer;
 
-	if (delta.action == network::ServerAction::Place) {
+	if (delta.action == GameAction::Place) {
 		if (delta.coord) {
-			m_board.place(Coord{delta.coord->x, delta.coord->y}, delta.seat == network::Seat::Black ? Board::Stone::Black : Board::Stone::White);
+			m_board.place(Coord{delta.coord->x, delta.coord->y}, toStone(delta.player));
 			for (const auto c: delta.captures) {
-				m_board.remove({c.x, c.y});
+				m_board.remove(c);
 			}
 		} else {
 			Logger().Log(Logging::LogLevel::Warning, "Game delta missing place coordinate; skipping board update.");
@@ -62,7 +62,7 @@ Player Position::getPlayer() const {
 	return m_player;
 }
 
-bool Position::isDeltaApplicable(const network::ServerDelta& delta) {
+bool Position::isDeltaApplicable(const GameDelta& delta) {
 	// No gamestate updates before game is active (received game configuration).
 	if (m_status != GameStatus::Active) {
 		Logger().Log(Logging::LogLevel::Error, "Received game update before game is active.");
@@ -70,19 +70,13 @@ bool Position::isDeltaApplicable(const network::ServerDelta& delta) {
 	}
 
 	// Game delta for the proper move.
-	if (delta.turn <= m_moveId) {
+	if (delta.moveId <= m_moveId) {
 		Logger().Log(Logging::LogLevel::Error, "Game delta sent to client twice.");
 		return false;
-	} else if (delta.turn > m_moveId + 1) {
+	} else if (delta.moveId > m_moveId + 1) {
 		Logger().Log(Logging::LogLevel::Error, "Game delta missing updates; applying latest update only.");
 
 		// TODO: Query missing move and apply update first.
-		return false;
-	}
-
-	// Player values valid
-	if (!network::isPlayer(delta.seat) || !network::isPlayer(delta.next)) {
-		Logger().Log(Logging::LogLevel::Error, "Received game update from non player seat.");
 		return false;
 	}
 


### PR DESCRIPTION
First, we abstract the GameSession. This is only a NetworkSession. Also separate the Chat functionality.
Now, we can start implementing a LocalSession, FreeplaySession, EngineSession, etc

Note: Presenter classes become Qt classes so we can properly connect signals with slots. Otherwise, 'this' pointers in the lambdas which connect to slots would become invalid on presenter replacement (as now done with the different game sessions)